### PR TITLE
fix: .gitattributes for thinBasic

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.tbasic eol=crlf
+*.tbasicu eol=crlf
+*.tbasici eol=crlf


### PR DESCRIPTION
ensures correct line endings